### PR TITLE
CI update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v1
         with:
-          version: v0.129.0
+          version: v0.144.1
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.9'
+          go-version: '1.14.9'
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v1
         with:


### PR DESCRIPTION
This PR updates the CI pipeline to:
- checkout unshallowed code directly
- build with Go v1.14.9
- build with goreleaser v0.144.1